### PR TITLE
Task 1: Initialize Deno project with ROSI structure and testing infrastructure

### DIFF
--- a/.claude/aboutme-index.json
+++ b/.claude/aboutme-index.json
@@ -1,1 +1,5 @@
-{}
+{
+  "slackbot/manifest.ts": "Slack app manifest defining the Regent Slack Bot configuration. Specifies app name, scopes, workflows, and bot user settings.",
+  "slackbot/src/mod.ts": "Main module entry point for slackbot implementation code. Re-exports public APIs from submodules as they are implemented.",
+  "slackbot/tests/example_test.ts": "Example test file demonstrating Deno test runner configuration. Verifies testing infrastructure is working correctly."
+}

--- a/.regent/regent-slack-bot/briefs/task-14.md
+++ b/.regent/regent-slack-bot/briefs/task-14.md
@@ -1,0 +1,130 @@
+# Task Brief
+
+## From Issue #14
+
+**Task 1**: Initialize Deno project with ROSI structure and testing infrastructure
+**Type**: infrastructure
+
+- Create directory layout (src/, tests/, manifest/)
+- Initialize deno.json with import maps and task definitions
+- Configure Deno test runner with coverage
+- Set up deno fmt and deno lint configuration
+- Create .gitignore for ROSI deployment artifacts
+
+### Requirements
+
+This is an infrastructure task with no direct requirement mappings. It establishes the project foundation for implementing all subsequent requirements.
+
+### Design Context
+
+The system is built on **Slack's ROSI (Run On Slack Infrastructure)** platform, which provides a serverless Deno/TypeScript runtime with integrated authentication and datastore capabilities.
+
+Architecture Requirements:
+- Deno/TypeScript runtime
+- Slack Datastore integration for session persistence
+- Support for slash commands and event handlers
+- Testing infrastructure with coverage tracking
+- Code quality tools (fmt, lint)
+
+### Task Relationships
+
+- **Depends on**: None (first task)
+- **Blocks**: Tasks 2-26 (all subsequent tasks require this foundation)
+- **TDD pair**: N/A (infrastructure task)
+
+## Codebase Context
+
+### Current Implementation State
+
+The slackbot directory has been **partially initialized** with the basic ROSI structure:
+
+**Existing files:**
+- `slackbot/manifest.ts` - App manifest with Slack scopes
+- `slackbot/deno.jsonc` - Deno configuration with task definitions
+- `slackbot/slack.json` - Slack CLI hooks
+- `slackbot/README.md` - Development documentation
+- `slackbot/.gitignore` - Basic ignores for .slack/, .deno/, deno.lock
+
+**Empty directories (ready for code):**
+- `functions/` - Will contain custom Slack functions
+- `workflows/` - Will contain workflow definitions
+- `triggers/` - Will contain trigger configurations
+
+**Not present yet:**
+- `src/` directory structure for implementation code
+- `tests/` directory for test files
+- TypeScript source files
+- Test configuration with coverage
+
+### ROSI Platform Patterns
+
+From manifest.ts and deno.jsonc:
+
+```typescript
+// Import pattern for Slack SDK
+import { Manifest } from "deno-slack-sdk/mod.ts";
+
+// deno.jsonc structure with import maps
+"imports": {
+  "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@2.14.3/",
+  "deno-slack-api/": "https://deno.land/x/deno_slack_api@2.8.0/"
+}
+
+// Task structure for development
+"tasks": {
+  "test": "deno test --allow-read --allow-net",
+  "check": "deno check **/*.ts",
+  "fmt": "deno fmt",
+  "lint": "deno lint"
+}
+```
+
+### Project Conventions
+
+**1. ABOUTME Header Convention**
+All code files must start with a 2-line comment with "ABOUTME: " prefix:
+```typescript
+// ABOUTME: Brief description of what this file does
+// ABOUTME: Second line with more detail if needed
+```
+
+**2. TypeScript/Deno Conventions**
+- Use TypeScript with strict mode enabled
+- Line width: 100 characters
+- Semi-colons: required
+- Double quotes for strings
+- Recommended linting rules
+- Structured with import maps in deno.jsonc
+
+**3. Directory Organization Pattern**
+```
+slackbot/
+├── src/           # Implementation code organized by domain
+├── tests/         # Test files mirroring src structure
+├── functions/     # Slack ROSI function entry points
+├── workflows/     # Workflow definitions
+├── triggers/      # Event trigger configurations
+└── manifest.ts    # Slack app manifest
+```
+
+### Files to Create
+
+1. **`slackbot/src/`** - Main implementation directory
+   - Create with a placeholder or README to establish structure
+
+2. **`slackbot/tests/`** - Test directory
+   - Mirror structure of src/
+   - Add example test to verify configuration
+
+### Files to Update
+
+1. **`slackbot/deno.jsonc`**
+   - Add coverage configuration task
+   - Add import maps for testing libraries (std/testing)
+
+2. **`slackbot/.gitignore`** (verify completeness)
+   - Ensure all ROSI artifacts are excluded
+
+---
+*Branch: regent-slack-bot/task-14*
+*Generated at execution time by Regent*

--- a/.regent/regent-slack-bot/tasks.md
+++ b/.regent/regent-slack-bot/tasks.md
@@ -2,7 +2,7 @@
 
 ## Project Setup
 
-- [ ] 1. Initialize Deno project with ROSI structure and testing infrastructure (#14)
+- [x] 1. Initialize Deno project with ROSI structure and testing infrastructure (#14)
   - Create directory layout (src/, tests/, manifest/)
   - Initialize deno.json with import maps and task definitions
   - Configure Deno test runner with coverage

--- a/slackbot/.gitignore
+++ b/slackbot/.gitignore
@@ -4,6 +4,7 @@
 # Deno
 .deno/
 deno.lock
+coverage/
 
 # Environment
 .env

--- a/slackbot/deno.jsonc
+++ b/slackbot/deno.jsonc
@@ -5,7 +5,9 @@
   },
   "imports": {
     "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@2.14.3/",
-    "deno-slack-api/": "https://deno.land/x/deno_slack_api@2.8.0/"
+    "deno-slack-api/": "https://deno.land/x/deno_slack_api@2.8.0/",
+    "@std/assert": "jsr:@std/assert@1",
+    "@std/testing/bdd": "jsr:@std/testing@1/bdd"
   },
   "fmt": {
     "lineWidth": 100,
@@ -19,6 +21,7 @@
   },
   "tasks": {
     "test": "deno test --allow-read --allow-net",
+    "test:coverage": "deno test --allow-read --allow-net --coverage=coverage && deno coverage coverage",
     "check": "deno check **/*.ts",
     "fmt": "deno fmt",
     "lint": "deno lint"

--- a/slackbot/src/mod.ts
+++ b/slackbot/src/mod.ts
@@ -1,0 +1,5 @@
+// ABOUTME: Main module entry point for slackbot implementation code.
+// ABOUTME: Re-exports public APIs from submodules as they are implemented.
+
+// This file serves as the main entry point for the slackbot implementation.
+// Submodules will be added and re-exported here as they are developed.

--- a/slackbot/tests/example_test.ts
+++ b/slackbot/tests/example_test.ts
@@ -1,0 +1,15 @@
+// ABOUTME: Example test file demonstrating Deno test runner configuration.
+// ABOUTME: Verifies testing infrastructure is working correctly.
+
+import { assertEquals } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+
+describe("Testing Infrastructure", () => {
+  it("should run a basic assertion", () => {
+    assertEquals(1 + 1, 2);
+  });
+
+  it("should handle string comparisons", () => {
+    assertEquals("hello", "hello");
+  });
+});


### PR DESCRIPTION
## Summary

- Create `src/` and `tests/` directory structure for modular code organization
- Add testing infrastructure with `@std/assert` and `@std/testing/bdd` imports
- Configure coverage task (`deno task test:coverage`)
- Update `.gitignore` for coverage artifacts

## Changes

- `slackbot/src/mod.ts`: Main module entry point (placeholder)
- `slackbot/tests/example_test.ts`: Example test verifying infrastructure works
- `slackbot/deno.jsonc`: Added testing imports and coverage task
- `slackbot/.gitignore`: Added `coverage/` directory
- `.regent/regent-slack-bot/tasks.md`: Marked task 1 complete
- `.regent/regent-slack-bot/briefs/task-14.md`: Task execution brief

## Testing

- Tests can be run with `deno task test` once Deno is installed
- Coverage can be generated with `deno task test:coverage`
- Tests use BDD-style `describe/it` syntax from `@std/testing/bdd`

## Requirements Satisfied

This is an infrastructure task with no direct requirement mappings. It establishes the project foundation for implementing all subsequent requirements (Tasks 2-26).

---
Closes #14

*Implemented via Regent*