### PR TITLE
feat: add explore-codebase GitHub Actions workflow

### DIFF
--- a/.github/prompts/exploration.md
+++ b/.github/prompts/exploration.md
@@ -1,0 +1,88 @@
+<!-- ABOUTME: Prompt template for Claude Code CLI codebase exploration. -->
+<!-- ABOUTME: Instructs Claude to analyze a repository and output structured JSON. -->
+
+# Codebase Exploration Prompt
+
+You are analyzing a codebase to help someone brainstorm a new feature or idea. Your goal is to understand the project structure, patterns, and integration points that would be relevant when planning new development.
+
+## Your Task
+
+Explore this codebase thoroughly and provide a structured analysis. You have two goals:
+
+### Goal 1: Understand the Project
+
+1. **What is this project?** - Languages, frameworks, and purpose
+2. **How is it organized?** - Directory structure, entry points, main components
+3. **What patterns does it use?** - Design patterns, conventions, abstractions
+4. **What does it integrate with?** - APIs, services, databases, external dependencies
+5. **How is it tested?** - Test structure, frameworks, conventions
+6. **What files are most important?** - Key files for understanding the codebase
+
+### Goal 2: Find Code Related to the Idea
+
+Search the codebase for anything related to the user's idea/feature. Look for:
+
+- **Existing similar features** - Code that does something similar to what they want to build
+- **Related domain concepts** - Models, types, or modules that touch on the same domain
+- **Potential integration points** - Where new code would likely hook into existing code
+- **Naming conventions** - How similar concepts are named in this codebase
+- **Prior art** - Any existing implementations they could extend or learn from
+
+For example, if the idea is "customer preferences", search for:
+- Files/code mentioning "preference", "setting", "config", "customer", "user"
+- Existing preference or settings systems
+- User profile or customer data models
+- UI components for settings/preferences
+- APIs that handle user customization
+
+## Output Format
+
+You MUST respond with ONLY valid JSON matching this exact structure. Do not include any other text, markdown, or explanation outside the JSON object:
+
+```json
+{
+  "project_overview": "A clear description of what this project is, including the primary programming language(s), frameworks used, and the project's main purpose. Example: 'A TypeScript/Deno Slack bot application using the Slack ROSI platform for collaborative spec-driven development workflows.'",
+  "architecture_summary": "A summary of the key directories, entry points, and main components. Example: 'Main entry: src/main.ts. Key directories: /functions (Slack function handlers), /workflows (workflow definitions), /lib (shared utilities). Uses event-driven architecture with Slack's function framework.'",
+  "relevant_patterns": [
+    "Pattern 1: Description of a design pattern, convention, or abstraction used",
+    "Pattern 2: Another pattern found in the codebase"
+  ],
+  "integration_points": [
+    "Integration 1: Description of an API, service, or external dependency",
+    "Integration 2: Another integration point"
+  ],
+  "testing_approach": "Description of the testing setup, frameworks used, test file locations, and any testing conventions. Example: 'Uses Deno's built-in test runner. Tests co-located with source files using .test.ts suffix. Mocking via Deno's testing utilities.'",
+  "key_files": [
+    "path/to/important/file1.ts",
+    "path/to/important/file2.ts"
+  ],
+  "idea_related_code": {
+    "summary": "Brief summary of what was found related to the user's idea. Example: 'Found existing user settings system in /src/settings/ with UserPreferences model. No customer-specific preferences yet, but the pattern is extensible.'",
+    "existing_similar_features": [
+      "Description of existing feature that's similar or related",
+      "Another related feature"
+    ],
+    "relevant_files": [
+      "path/to/related/file1.ts - Why this file is relevant",
+      "path/to/related/file2.ts - What it contains that matters"
+    ],
+    "suggested_integration_points": [
+      "Where/how new code could integrate with existing code"
+    ]
+  }
+}
+```
+
+## Guidelines
+
+- Be concise but informative in your descriptions
+- Focus on aspects relevant to extending or modifying the codebase
+- Include 3-8 items for arrays (patterns, integrations, key_files)
+- Use actual file paths from the codebase for key_files and relevant_files
+- If the codebase is small or simple, it's okay to have fewer items
+- For `idea_related_code`: actively search the codebase using keywords from the idea
+- If nothing related to the idea is found, say so honestly in the summary and leave arrays empty
+
+## Important
+
+Your response must be ONLY the JSON object. Do not wrap it in markdown code blocks in your final output. Do not include any explanatory text before or after the JSON.

--- a/.github/workflows/explore-codebase.yml
+++ b/.github/workflows/explore-codebase.yml
@@ -1,0 +1,267 @@
+# ABOUTME: GitHub Actions workflow for deep codebase exploration using Claude Code CLI.
+# ABOUTME: Triggered by workflow_dispatch, explores a target repo and POSTs results to callback URL.
+
+name: Explore Codebase
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_repo:
+        description: 'Repository to explore (owner/repo format)'
+        required: true
+        type: string
+      idea:
+        description: 'The idea/feature being brainstormed'
+        required: true
+        type: string
+      callback_url:
+        description: 'URL to POST results to'
+        required: true
+        type: string
+      session_id:
+        description: 'Session ID for correlation'
+        required: true
+        type: string
+
+# Prevent concurrent explorations for the same session
+concurrency:
+  group: exploration-${{ inputs.session_id }}
+  cancel-in-progress: true
+
+jobs:
+  explore:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Validate inputs
+        id: validate
+        env:
+          TARGET_REPO: ${{ inputs.target_repo }}
+          CALLBACK_URL: ${{ inputs.callback_url }}
+          SESSION_ID: ${{ inputs.session_id }}
+        run: |
+          # Validate target_repo format (owner/repo, alphanumeric with dots, dashes, underscores)
+          if ! [[ "$TARGET_REPO" =~ ^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$ ]]; then
+            echo "::error::Invalid target_repo format: must be 'owner/repo'"
+            exit 1
+          fi
+
+          # Validate callback_url is HTTPS
+          if ! [[ "$CALLBACK_URL" =~ ^https:// ]]; then
+            echo "::error::Invalid callback_url: must use HTTPS"
+            exit 1
+          fi
+
+          # Validate session_id is non-empty and alphanumeric (with dashes/underscores)
+          if ! [[ "$SESSION_ID" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+            echo "::error::Invalid session_id format"
+            exit 1
+          fi
+
+          echo "All inputs validated successfully"
+
+      - name: Checkout this repo (for prompt template)
+        uses: actions/checkout@v4
+
+      - name: Clone target repository
+        id: clone
+        continue-on-error: true
+        env:
+          TARGET_REPO: ${{ inputs.target_repo }}
+          REPO_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
+        run: |
+          echo "Cloning repository..."
+          # Use git credential helper to avoid embedding token in URL
+          git config --global credential.helper store
+          echo "https://x-access-token:${REPO_TOKEN}@github.com" > ~/.git-credentials
+
+          # Clone with credentials from helper (token not in command line)
+          if ! git clone --depth 1 "https://github.com/${TARGET_REPO}.git" ./target-repo 2>&1; then
+            echo "clone_error=Failed to clone repository" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+
+          # Clean up credentials file
+          rm -f ~/.git-credentials
+          echo "clone_success=true" >> $GITHUB_OUTPUT
+
+      - name: Setup Node.js
+        if: steps.clone.outcome == 'success'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Claude Code CLI
+        if: steps.clone.outcome == 'success'
+        id: install
+        continue-on-error: true
+        run: |
+          if ! npm install -g @anthropic-ai/claude-code 2>&1; then
+            echo "install_error=Failed to install Claude Code CLI" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+          echo "install_success=true" >> $GITHUB_OUTPUT
+
+      - name: Run codebase exploration
+        if: steps.clone.outcome == 'success' && steps.install.outcome == 'success'
+        id: explore
+        continue-on-error: true
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          IDEA: ${{ inputs.idea }}
+        run: |
+          cd ./target-repo
+
+          # Read the exploration prompt template
+          PROMPT_TEMPLATE=$(cat "$GITHUB_WORKSPACE/.github/prompts/exploration.md")
+
+          # Write the full prompt to a temp file to avoid heredoc expansion issues
+          # Using printf to safely handle special characters
+          {
+            printf '%s\n\n' "$PROMPT_TEMPLATE"
+            printf '## Context for This Exploration\n\n'
+            printf 'The user is brainstorming the following idea/feature:\n\n'
+            printf '%s\n\n' "$IDEA"
+            printf 'Focus your analysis on aspects of the codebase most relevant to implementing this idea.\n'
+          } > /tmp/exploration_prompt.txt
+
+          # Run Claude Code CLI and capture output
+          echo "Running Claude Code exploration..."
+          if ! claude --print "$(cat /tmp/exploration_prompt.txt)" > "$GITHUB_WORKSPACE/exploration_output.txt" 2>&1; then
+            echo "explore_error=Claude Code CLI failed" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+          echo "explore_success=true" >> $GITHUB_OUTPUT
+
+      - name: Parse and send success callback
+        if: steps.explore.outcome == 'success'
+        env:
+          CALLBACK_URL: ${{ inputs.callback_url }}
+          SESSION_ID: ${{ inputs.session_id }}
+          CALLBACK_SECRET: ${{ secrets.CALLBACK_SECRET }}
+        run: |
+          # Read the exploration output
+          EXPLORATION_OUTPUT=$(cat "$GITHUB_WORKSPACE/exploration_output.txt")
+
+          # Try to extract valid JSON from the output
+          # First, try the whole output as JSON
+          if echo "$EXPLORATION_OUTPUT" | jq -e . > /dev/null 2>&1; then
+            EXPLORATION_CONTEXT="$EXPLORATION_OUTPUT"
+          else
+            # Try to extract JSON object from mixed content
+            # Look for the outermost { } pair that forms valid JSON
+            EXPLORATION_CONTEXT=$(echo "$EXPLORATION_OUTPUT" | \
+              grep -Pzo '(?s)\{.*\}' | \
+              tr '\0' '\n' | \
+              jq -e . 2>/dev/null || echo "")
+
+            if [ -z "$EXPLORATION_CONTEXT" ]; then
+              # If still not valid JSON, create a fallback response with raw output
+              EXPLORATION_CONTEXT=$(jq -n \
+                --arg overview "$EXPLORATION_OUTPUT" \
+                '{
+                  project_overview: $overview,
+                  architecture_summary: "Unable to parse structured output from Claude",
+                  relevant_patterns: [],
+                  integration_points: [],
+                  testing_approach: "See project_overview for raw analysis",
+                  key_files: [],
+                  idea_related_code: {
+                    summary: "Unable to parse structured output - see project_overview for raw analysis",
+                    existing_similar_features: [],
+                    relevant_files: [],
+                    suggested_integration_points: []
+                  }
+                }')
+            fi
+          fi
+
+          # Construct the callback payload
+          PAYLOAD=$(jq -n \
+            --arg session_id "$SESSION_ID" \
+            --argjson context "$EXPLORATION_CONTEXT" \
+            '{
+              session_id: $session_id,
+              status: "success",
+              exploration_context: $context
+            }')
+
+          echo "Sending success callback..."
+
+          # Retry logic for transient failures (up to 3 attempts)
+          MAX_RETRIES=3
+          RETRY_DELAY=5
+          for i in $(seq 1 $MAX_RETRIES); do
+            if curl -X POST "$CALLBACK_URL" \
+              -H "Content-Type: application/json" \
+              -H "Authorization: Bearer $CALLBACK_SECRET" \
+              -d "$PAYLOAD" \
+              --fail --silent --show-error --max-time 30; then
+              echo "Callback sent successfully"
+              exit 0
+            fi
+            echo "Callback attempt $i failed, retrying in ${RETRY_DELAY}s..."
+            sleep $RETRY_DELAY
+          done
+
+          echo "::warning::Failed to send success callback after $MAX_RETRIES attempts"
+          exit 1
+
+      - name: Send error callback
+        if: steps.clone.outcome == 'failure' || steps.install.outcome == 'failure' || steps.explore.outcome == 'failure'
+        env:
+          CALLBACK_URL: ${{ inputs.callback_url }}
+          SESSION_ID: ${{ inputs.session_id }}
+          CALLBACK_SECRET: ${{ secrets.CALLBACK_SECRET }}
+          CLONE_OUTCOME: ${{ steps.clone.outcome }}
+          INSTALL_OUTCOME: ${{ steps.install.outcome }}
+          CLONE_ERROR: ${{ steps.clone.outputs.clone_error }}
+          INSTALL_ERROR: ${{ steps.install.outputs.install_error }}
+          EXPLORE_ERROR: ${{ steps.explore.outputs.explore_error }}
+        run: |
+          # Determine error message and code based on which step failed
+          if [ "$CLONE_OUTCOME" == "failure" ]; then
+            ERROR_MESSAGE="${CLONE_ERROR:-Failed to clone repository}"
+            ERROR_CODE="CLONE_FAILED"
+          elif [ "$INSTALL_OUTCOME" == "failure" ]; then
+            ERROR_MESSAGE="${INSTALL_ERROR:-Failed to install Claude Code CLI}"
+            ERROR_CODE="INSTALL_FAILED"
+          else
+            ERROR_MESSAGE="${EXPLORE_ERROR:-Exploration failed}"
+            ERROR_CODE="EXPLORATION_FAILED"
+          fi
+
+          # Construct error payload
+          PAYLOAD=$(jq -n \
+            --arg session_id "$SESSION_ID" \
+            --arg message "$ERROR_MESSAGE" \
+            --arg code "$ERROR_CODE" \
+            '{
+              session_id: $session_id,
+              status: "error",
+              error: {
+                message: $message,
+                code: $code
+              }
+            }')
+
+          echo "Sending error callback..."
+
+          # Retry logic for transient failures (up to 3 attempts)
+          MAX_RETRIES=3
+          RETRY_DELAY=5
+          for i in $(seq 1 $MAX_RETRIES); do
+            if curl -X POST "$CALLBACK_URL" \
+              -H "Content-Type: application/json" \
+              -H "Authorization: Bearer $CALLBACK_SECRET" \
+              -d "$PAYLOAD" \
+              --fail --silent --show-error --max-time 30; then
+              echo "Error callback sent successfully"
+              exit 0
+            fi
+            echo "Callback attempt $i failed, retrying in ${RETRY_DELAY}s..."
+            sleep $RETRY_DELAY
+          done
+
+          echo "::warning::Failed to send error callback after $MAX_RETRIES attempts"

--- a/.regent/regent-slack-bot/briefs/task-50.md
+++ b/.regent/regent-slack-bot/briefs/task-50.md
@@ -1,0 +1,179 @@
+# Task Brief
+
+## From Issue #50
+
+Parent Epic: #42
+
+## Task Description
+
+Create the GitHub Actions workflow for deep codebase exploration **in this repo** (simplified from original plan to create a separate repo - we'll keep everything in-repo for development/dogfooding).
+
+**Type**: test-first
+
+### Implementation Steps
+
+1. Create `.github/workflows/explore-codebase.yml` workflow in this repo:
+   - Accepts `workflow_dispatch` with inputs: `target_repo`, `idea`, `callback_url`, `session_id`
+   - Clones target repository using `REPO_ACCESS_TOKEN` secret
+   - Installs Claude Code CLI
+   - Runs exploration prompt with `claude --print`
+   - POSTs results to callback URL with `CALLBACK_SECRET` auth
+3. Create `prompts/exploration.md` template
+4. Configure repository secrets: `ANTHROPIC_API_KEY`, `REPO_ACCESS_TOKEN`, `CALLBACK_SECRET`
+5. Write tests for workflow execution (can use act or mock)
+
+### Workflow Inputs
+
+| Parameter | Description | Required |
+|-----------|-------------|----------|
+| `target_repo` | Repository to explore (`owner/repo`) | Yes |
+| `idea` | The idea/feature being brainstormed | Yes |
+| `callback_url` | ROSI webhook URL to POST results | Yes |
+| `session_id` | Session ID for correlation | Yes |
+
+### Callback POST Format
+
+```typescript
+interface ExplorationCallback {
+  session_id: string;
+  status: "success" | "error";
+  exploration_context?: {
+    project_overview: string;
+    architecture_summary: string;
+    relevant_patterns: string[];
+    integration_points: string[];
+    testing_approach: string;
+    key_files: string[];
+  };
+  error?: { message: string; code: string; };
+}
+```
+
+## Acceptance Criteria
+
+- Repository created with proper workflow file
+- Workflow triggers successfully via `workflow_dispatch`
+- Claude Code CLI runs exploration and returns structured results
+- Results POSTed to callback URL with proper authentication
+- Timeout set to 10 minutes for workflow
+
+_Requirements: 2.2, 2.3, 2.6_
+
+## Issue Discussion
+
+No comments on this issue.
+
+## Codebase Context
+
+### Design Architecture
+
+The `regent-exploration-service` is a central GitHub repository that solves the ROSI 60-second timeout constraint. It hosts a GitHub Actions workflow that:
+
+1. **Receives** `workflow_dispatch` triggers from the slackbot with these inputs:
+   - `target_repo` - Repository to explore (owner/repo format)
+   - `idea` - The feature/problem being brainstormed (used to focus analysis)
+   - `callback_url` - ROSI webhook URL to POST results
+   - `session_id` - Correlates results back to the session
+
+2. **Executes** deep codebase exploration (1-3 minutes, no timeout constraints):
+   - Clones the target repository
+   - Installs Claude Code CLI globally
+   - Runs exploration prompt through `claude --print`
+   - Captures structured analysis results
+
+3. **Reports** results back via webhook:
+   - POSTs to the callback URL with `Authorization: Bearer {CALLBACK_SECRET}`
+   - Includes `session_id`, `status` ("success"|"error"), and `exploration_context`
+   - Enables slackbot to continue the Q&A flow with codebase context
+
+### Requirements Context
+
+**Requirement 2.2 - Deep Codebase Analysis:**
+> WHEN exploring a repository THEN the system SHALL trigger a GitHub Actions workflow asynchronously to perform deep codebase analysis using Claude Code CLI; this exploration may take 1-3 minutes to complete.
+
+**Requirement 2.3 - Webhook Results Processing:**
+> WHEN the GitHub Actions exploration workflow completes THEN the system SHALL receive results via webhook callback and post a summary of findings (framework, patterns, relevant existing code) before asking the first question.
+
+### Integration Points
+
+The `SessionOrchestrator` initiates exploration during `/brainstorm` command handling:
+
+1. **Session Creation**: Creates a session record via `SessionManager.createSession()`
+2. **Trigger Check**: If `command.repository` is provided, calls `exploreRepositoryWithErrorHandling()`
+3. **User Notification**: Posts "Exploring codebase... (this may take a few minutes)" to Slack
+4. **Async Dispatch**: Calls `GitHubClient.exploreRepository()` which delegates to GitHub Actions
+
+The slackbot receives results via webhook at `POST /webhook/exploration-complete`:
+- Validates `Authorization: Bearer {CALLBACK_SECRET}` header
+- Extracts `session_id`, `status`, `exploration_context`
+- Calls `SessionOrchestrator.handleExplorationResult()`
+
+### Files to Create (in this repo)
+
+```
+regent/
+├── .github/
+│   ├── workflows/
+│   │   └── explore-codebase.yml          # GitHub Actions workflow definition
+│   └── prompts/
+│       └── exploration.md                 # Claude Code exploration prompt
+
+# Secrets to configure in stickystyle/regent repo settings:
+# - REPO_ACCESS_TOKEN: GitHub PAT with repo:read access to target repos
+# - ANTHROPIC_API_KEY: Anthropic API key for Claude Code CLI
+# - CALLBACK_SECRET: Shared secret for webhook authentication
+```
+
+### Workflow Structure
+
+The `explore-codebase.yml` should:
+1. **Trigger**: `workflow_dispatch` with four required inputs
+2. **Environment Setup**:
+   - Check out self (exploration-service repo)
+   - Clone target repository using `REPO_ACCESS_TOKEN`
+3. **Claude Code CLI Setup**:
+   - Install Node.js
+   - `npm install -g @anthropic-ai/claude-code`
+4. **Run Exploration**:
+   - Use `claude --print` with exploration.md prompt
+   - Include `--context "Idea: {idea}"` to focus analysis
+5. **Error Handling**:
+   - Catch errors during clone, install, exploration
+   - POST error response with status: "error" and error details
+6. **Webhook Callback**:
+   - Parse exploration results
+   - POST to callback_url with Bearer token auth
+
+### Exploration Prompt Template
+
+The `prompts/exploration.md` should guide Claude Code to provide:
+1. Project Overview - What is this project, frameworks, languages?
+2. Architecture Summary - Key directories, entry points, main components
+3. Relevant Patterns - Design patterns, conventions, abstractions
+4. Integration Points - APIs, services, databases, external dependencies
+5. Testing Approach - Test structure, frameworks, conventions
+
+Output should match the `ExplorationCallback` interface.
+
+### Key Design Decisions
+
+1. **Separated Repository**: Standalone repo (not in monorepo) for:
+   - Different deployment lifecycle
+   - Can be shared across multiple Regent installations
+   - Cleaner permission boundaries
+
+2. **Webhook Callback Pattern**: Results POST back rather than polling:
+   - Enables immediate continuation
+   - Aligns with async pattern of GitHub Actions
+
+3. **Claude Code CLI**: Uses `claude --print` rather than SDK:
+   - Exploration is "run once, get results"
+   - Simpler subprocess invocation in GitHub Actions
+
+4. **Bearer Token Auth**: `Authorization: Bearer {CALLBACK_SECRET}`:
+   - Simple shared secret model
+   - CALLBACK_SECRET generated and shared between repos
+
+---
+*Branch: feature/regent-slack-bot*
+*Generated at execution time by Regent*


### PR DESCRIPTION
## Summary

Cherry-pick of the explore-codebase workflow from `feature/regent-slack-bot` to enable testing on main.

- Adds `.github/workflows/explore-codebase.yml` - GitHub Actions workflow for deep codebase exploration
- Adds `.github/prompts/exploration.md` - Claude Code prompt template
- Adds `.regent/regent-slack-bot/briefs/task-50.md` - Task brief (from issue #50)

## Why Cherry-Pick?

The full `feature/regent-slack-bot` branch is part of a larger epic with many pending tasks. This cherry-pick allows us to test the workflow immediately since `workflow_dispatch` requires the workflow file to exist on the default branch.

## Required Secrets

Configure these in repo settings before testing:
- `ANTHROPIC_API_KEY` - For Claude Code CLI
- `REPO_ACCESS_TOKEN` - GitHub PAT with repo read access
- `CALLBACK_SECRET` - Shared secret for webhook auth

## Test Plan

After merge, trigger via:
```bash
gh workflow run explore-codebase.yml \
  -f target_repo="stickystyle/regent" \
  -f idea="Add customer preferences system" \
  -f callback_url="https://webhook.site/..." \
  -f session_id="test-001"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)